### PR TITLE
Update to Node 10 (new LTS) and fix #4

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,9 +1,11 @@
-FROM node:8
+FROM node:10
 
 LABEL maintainer="yeongjinnn@gmail.com"
 
 # See https://crbug.com/795759
 RUN apt-get update && apt-get install -yq libgconf-2-4
+
+ENV APT_KEY_DONT_WARN_ON_DANGEROUS_USAGE=1
 
 # Install latest chrome package.
 # Note: this installs the necessary libs to make the bundled version of Chromium that Pupppeteer


### PR DESCRIPTION
Bumped to `node:10` since v10 is the new [active LTS of NodeJS](https://nodejs.org/en/about/releases).

Also fixed "Warning: apt-key output should not be parsed (stdout is not a terminal)" during Image build by setting `APT_KEY_DONT_WARN_ON_DANGEROUS_USAGE=1` (see <https://stackoverflow.com/questions/48162574/how-to-circumvent-apt-key-output-should-not-be-parsed>)